### PR TITLE
Fix: Cast numeric write-concern values from XML mapping to integers

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -158,7 +158,11 @@ class XmlDriver extends FileDriver
         }
 
         if (isset($xmlRoot['write-concern'])) {
-            $metadata->setWriteConcern((string) $xmlRoot['write-concern']);
+            $writeConcern = (string) $xmlRoot['write-concern'];
+            if(is_numeric($writeConcern)) {
+                $writeConcern = (int) $writeConcern;
+            }
+            $metadata->setWriteConcern($writeConcern);
         }
 
         if (isset($xmlRoot['inheritance-type'])) {


### PR DESCRIPTION
When using write-concern="1" in XML mapping, the value was being cast to string, causing MongoDB to interpret it as a named write concern mode instead of a numeric level. This led to errors like: "No write concern mode named '1' found in replica set configuration".

This commit ensures that numeric write concern values are properly cast to integers, while still allowing named modes such as "majority" to be used as strings.
